### PR TITLE
remove redundant geneartion

### DIFF
--- a/js/alternate.js
+++ b/js/alternate.js
@@ -97,7 +97,7 @@ function generateAlternate(selection) {
 
   if (selection === 'Acronyms') {
     let counter = 2
-    let results = generateAcronym(counter, wordList, useEntropy)
+    let results
 
     do {
       results = generateAcronym(counter, wordList, useEntropy)


### PR DESCRIPTION
There's no reason to generate the acronym twice in the beginning. This will result in you generating an acronym twice for the same counter value before it increments to the next counter value.